### PR TITLE
Reduce per-line LLM calls for batch processing

### DIFF
--- a/generate_timed_segments.py
+++ b/generate_timed_segments.py
@@ -1005,7 +1005,7 @@ def split_script_to_lines(script_text: str, mode="llm") -> list[str]:
     if not text:
         return []
 
-    # ✨ 개행이 있으면 우선 하드 경계로 쪼갬
+    # 개행 기준 강제 분할
     if "\n" in text:
         base_lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
     else:
@@ -1014,11 +1014,10 @@ def split_script_to_lines(script_text: str, mode="llm") -> list[str]:
     if mode == "newline":
         return base_lines
 
-    # mode == "llm": 각 줄을 breath_linebreaks에 넣되, honor_newlines=True로 추가 분절 방지
-    out = []
-    for line in base_lines:
-        out.extend(breath_linebreaks(line, honor_newlines=True))
-    return out
+    # mode == "llm": 전체 대본을 한 번에 LLM에 전달해 분절 라인 배열 반환
+    joined = "\n".join(base_lines)
+    lines = breath_linebreaks_batch(joined)
+    return [ln.strip() for ln in lines if ln.strip()]
 
 # --- 변경 2: generate_subtitle_from_script 시그니처/로직 확장 ---
 def generate_subtitle_from_script(

--- a/ssml_converter.py
+++ b/ssml_converter.py
@@ -99,30 +99,14 @@ def koreanize_if_english(text: str) -> str:
     if not t or not _looks_english(t):
         return t
 
-    # 1) LLM 시도 (의미 동일 한국어 한 문장)
-    prompt = (
-        "역할: 너는 한국어 문장 변환기다.\n"
-        "출력은 한국어 **한 문장**만. 마크다운/주석/설명 금지.\n"
-        "규칙: 의미를 100% 유지. 숫자/단위/고유명사는 보존. 문장 끝 어미는 평서체.\n\n"
-        "[입력]\n" + t + "\n\n[출력]\n"
-    )
-    try:
-        out = _complete_with_any_llm(prompt)
-        if out and out.strip():
-            # 안전 정리
-            s = re.sub(r"\s+", " ", out).strip()
-            return s
-    except Exception:
-        pass
-
-    # 2) 폴백: Google 번역
+    # LLM 호출 없이 Google 번역만 사용하여 한국어로 변환
     if GoogleTranslator is not None:
         try:
             return GoogleTranslator(source="auto", target="ko").translate(t)
         except Exception:
             pass
 
-    # 3) 실패 시 원문 유지
+    # 번역 실패 시 원문 유지
     return t
     
 def _heuristic_breath_lines(text: str, strict: bool = True) -> list[str]:


### PR DESCRIPTION
## Summary
- Use Google translation only in `koreanize_if_english` to avoid per-line LLM calls
- Split scripts with single batched LLM request in `split_script_to_lines`

## Testing
- `python -m py_compile ssml_converter.py generate_timed_segments.py keyword_generator.py runner.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bceb0f2d088324a00aff863fd5b8e8