### PR TITLE
Batch segmentation and sanitized subtitles

### DIFF
--- a/best_subject_subtitle_extractor.py
+++ b/best_subject_subtitle_extractor.py
@@ -5,7 +5,6 @@ import subprocess
 import unicodedata
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import streamlit as st
-from deep_translator import GoogleTranslator
 from googleapiclient.discovery import build
 from yt_dlp import YoutubeDL
 
@@ -22,17 +21,10 @@ os.makedirs(TXT_DIR, exist_ok=True)
 
 model = whisper.load_model("base")
 
-# 안전한 영어 파일명 생성
+# 안전한 파일명 생성
 def safe_filename(title):
-    """한글 제목이면 영어로 번역해서 안전한 파일명 생성"""
-    if any('\uac00' <= c <= '\ud7a3' for c in title):
-        try:
-            translated = GoogleTranslator(source='ko', target='en').translate(title)
-        except Exception:
-            translated = title
-    else:
-        translated = title
-    safe_title = unicodedata.normalize("NFKD", translated)
+    """한글 포함 여부와 관계없이 안전한 파일명 생성"""
+    safe_title = unicodedata.normalize("NFKD", title)
     safe_title = safe_title.encode("ascii", "ignore").decode("ascii")
     safe_title = re.sub(r'[\\/*?:"<>|#;]', "", safe_title)
     safe_title = safe_title.strip().replace(" ", "_")

--- a/best_subtitle_extractor.py
+++ b/best_subtitle_extractor.py
@@ -4,7 +4,6 @@ import whisper
 import subprocess
 import unicodedata
 import streamlit as st
-from deep_translator import GoogleTranslator
 from googleapiclient.discovery import build
 from yt_dlp import YoutubeDL
 from langchain_core.documents import Document as LangChainDocument
@@ -74,15 +73,8 @@ def resolve_channel_id(input_str):
 # 📝 [파일명 변환, 오디오 다운로드 등]
 # ===============================
 def safe_filename(title):
-    """한글 제목이면 영어로 번역해서 안전한 파일명 생성"""
-    if any('\uac00' <= c <= '\ud7a3' for c in title):
-        try:
-            translated = GoogleTranslator(source='ko', target='en').translate(title)
-        except Exception:
-            translated = title
-    else:
-        translated = title
-    safe_title = unicodedata.normalize("NFKD", translated)
+    """한글 포함 여부와 관계없이 안전한 파일명 생성"""
+    safe_title = unicodedata.normalize("NFKD", title)
     safe_title = safe_title.encode("ascii", "ignore").decode("ascii")
     safe_title = re.sub(r'[\\/*?:"<>|#;]', "", safe_title)
     safe_title = safe_title.strip().replace(" ", "_")

--- a/image_generator.py
+++ b/image_generator.py
@@ -9,28 +9,14 @@ load_dotenv()
 PEXELS_API_KEY = os.getenv("PEXELS_API_KEY")
 
 # === Add: English-enforcer ===
-import re
 from functools import lru_cache
-try:
-    from deep_translator import GoogleTranslator
-except Exception:
-    GoogleTranslator = None
 
 @lru_cache(maxsize=1024)
 def _ensure_english(text: str) -> str:
     t = (text or "").strip()
     if not t:
         return t
-    # 이미 영문/숫자/기본 기호만 있으면 그대로
-    if re.fullmatch(r"[A-Za-z0-9 ,./°%-]+", t):
-        return t
-    # deep_translator 사용 가능 시 자동 번역
-    if GoogleTranslator is not None:
-        try:
-            return GoogleTranslator(source="auto", target="en").translate(t) or t
-        except Exception:
-            pass
-    return t  # 실패 시 원문 유지
+    return t
 
 # ===== Global throttle & cache =====
 # 연속 호출 사이 최소 간격(초). 300~500ms 권장.

--- a/main.py
+++ b/main.py
@@ -19,8 +19,7 @@ from video_maker import (
     add_subtitles_to_video,
     create_dark_text_video
 )
-from ssml_converter import convert_lines_to_ssml_batch, breath_linebreaks_batch, koreanize_if_english
-from deep_translator import GoogleTranslator
+from ssml_converter import convert_lines_to_ssml_batch, breath_linebreaks_batch
 from file_handler import get_documents_from_files
 from upload import upload_to_youtube
 from best_subtitle_extractor import load_best_subtitles_documents
@@ -32,7 +31,8 @@ import re
 import json
 import hashlib as _hl
 import pandas as pd
-from io import BytesIO
+from io import BytesIO, StringIO
+import importlib
 import nest_asyncio
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_google_genai import GoogleGenerativeAIEmbeddings
@@ -47,13 +47,11 @@ VIDEO_TEMPLATE = "영상(영어보이스+한국어자막·가운데)"
 DEFAULT_BGM = "assets/[BGM] 힙합 비트 신나는 음악  무료브금  HYP-Show Me - HYP MUSIC - BGM Design.mp3"
 
 # ---------- 유틸 ----------
-def _split_script_for_tts(script_text: str) -> list[str]:
-    """
-    전체 대본을 LLM에 한 번 전달해 분절된 라인 배열을 받아온다.
-    """
+def _split_script_into_sentences(script_text: str) -> list[str]:
+    """구두점 기준 문장 분할 (LLM 사용 없음)"""
     text = script_text or ""
-    lines = breath_linebreaks_batch(text)  # ✅ 배치용 함수 사용
-    return [ln.strip() for ln in lines if ln.strip()]
+    parts = re.split(r"(?<=[.!?])\s+", text.strip())
+    return [p.strip() for p in parts if p.strip()]
 
 
 # === 기존 build_ssml_log_file 대체 ===
@@ -105,16 +103,15 @@ def build_ssml_log_file(
     csv_bytes = sbuf.getvalue().encode("utf-8-sig")
     return csv_bytes, "csv", "text/csv"
 
-def _log_ssml_preview(line: str, provider: str, voice_template: str, polly_voice_key: str, subtitle_lang: str):
+def _log_ssml_preview(line: str, provider: str, voice_template: str, polly_voice_key: str):
     """
     단일 라인 SSML 미리보기 로그.
     - 자막용 텍스트(line)는 원문 그대로 출력.
-    - 발화용은 koreanize_if_english(line) 후 SSML 변환.
+    - 발화용은 SSML 변환만 수행.
     """
     try:
         orig_text = line.strip()
-        ssml_input = koreanize_if_english(orig_text)  # 음성용 변환
-        ssml_list = convert_lines_to_ssml_batch([ssml_input])
+        ssml_list = convert_lines_to_ssml_batch([orig_text])
         ssml = ssml_list[0] if ssml_list else ""
         st.write(f"🧪 [SSML 미리보기] {orig_text}")  # ✅ 자막은 원문 그대로
         st.code(ssml, language="xml")               # ✅ SSML은 발화용
@@ -196,7 +193,6 @@ def build_sentence_video_segments(sentence_segments, dense_events, audio_path=No
 
     return out_sorted
 
-import hashlib, os
 
 def _fingerprint_video(path: str) -> str:
     """
@@ -850,14 +846,10 @@ def get_scene_keywords_batch(sentence_units, persona_text: str):
         if 0 <= idx < len(out):
             out[idx] = _normalize_scene_query(m.group(2))
 
-    # 비어 있는 건 문장 원문을 영어로 번역해서 폴백
+    # 비어 있는 항목은 원문 그대로 정리
     for i, val in enumerate(out):
         if not val:
-            try:
-                t = GoogleTranslator(source='auto', target='en').translate(sentence_units[i])
-            except Exception:
-                t = sentence_units[i]
-            out[i] = _normalize_scene_query(t)
+            out[i] = _normalize_scene_query(sentence_units[i])
 
     return out
 
@@ -1171,6 +1163,10 @@ with st.sidebar:
                 st.error("영상 제목이 비어있습니다.")
                 st.stop()
 
+            # ✅ 사전 분절: 전체 대본 → 라인 배열 (LLM 1회 호출)
+            sentence_lines = _split_script_into_sentences(final_script_for_video)
+            clause_lines = breath_linebreaks_batch(final_script_for_video)
+
             with st.spinner("✨ 영상 제작 중입니다..."):
                 try:
                     media_query_final = ""
@@ -1187,25 +1183,26 @@ with st.sidebar:
                         audio_path = os.path.join(audio_output_dir, "generated_audio.mp3")
 
                         st.write("🗣️ 라인별 TTS 생성/병합 및 세그먼트 산출 중...")
-                        provider = "elevenlabs" if st.session_state.selected_tts_provider == "ElevenLabs" else "polly"
-                        tmpl = st.session_state.selected_tts_template if provider == "elevenlabs" else st.session_state.selected_polly_voice_key
-                        
-                        script_text = koreanize_if_english(final_script_for_video)
-                        script_text_for_tts = "\n".join(sentence_lines)
-                        
+                        tts_provider = "elevenlabs" if st.session_state.selected_tts_provider == "ElevenLabs" else "polly"
+                        voice_template = (
+                            st.session_state.selected_tts_template
+                            if tts_provider == "elevenlabs"
+                            else st.session_state.selected_polly_voice_key
+                        )
+                        polly_voice_key = st.session_state.selected_polly_voice_key
+
                         # ✅ 토큰 없이 로그 만들 수 있도록 세션에 저장
-                        st.session_state["_orig_lines_for_tts"] = sentence_lines[:]   # 원문 라인(브레스 결과)
-                        st.session_state["_used_br_lines"]      = sentence_lines[:]   # 브레스 라인 그대로
-                        
+                        st.session_state["_orig_lines_for_tts"] = clause_lines[:]
+                        st.session_state["_used_br_lines"]      = clause_lines[:]
+
                         segments, audio_clips, ass_path = generate_subtitle_from_script(
-                            script_text,
+                            final_script_for_video,
                             ass_path,
                             provider=tts_provider,
                             template=voice_template,
                             polly_voice_key=polly_voice_key,
-                            subtitle_lang=subtitle_lang,
-                            translate_only_if_english=translate_only_if_english,
-                            strip_trailing_punct_last=True
+                            strip_trailing_punct_last=True,
+                            pre_split_lines=clause_lines,
                         )
 
                         # === SSML 변환 '후' (실사용본) ===

--- a/runner.py
+++ b/runner.py
@@ -41,8 +41,6 @@ def run_job(job):
             provider=job.get("tts_provider", "polly"),
             template=job.get("voice_template", "default"),
             polly_voice_key=job.get("polly_voice_key", "korean_female1"),
-            subtitle_lang=job.get("subtitle_lang", "ko"),
-            translate_only_if_english=job.get("translate_only_if_english", False),
             strip_trailing_punct_last=True,
         )
 

--- a/ssml_converter.py
+++ b/ssml_converter.py
@@ -7,11 +7,6 @@ try:
 except Exception:
     complete_text = None
 
-try:
-    from deep_translator import GoogleTranslator
-except Exception:
-    GoogleTranslator = None
-
 # ssml_converter.py
 import json
 from typing import List
@@ -87,44 +82,6 @@ def convert_lines_to_ssml_batch(lines: List[str]) -> List[str]:
 
     return ssml_list
 
-def _looks_english(text: str) -> bool:
-    if not text: return False
-    en = len(re.findall(r"[A-Za-z]", text))
-    ko = len(re.findall(r"[\uac00-\ud7a3]", text))
-    return en >= 3 and en > ko * 1.2
-
-def koreanize_if_english(text: str) -> str:
-    """문장이 사실상 영어면, 의미 동일 한국어 한 문장으로 변환."""
-    t = (text or "").strip()
-    if not t or not _looks_english(t):
-        return t
-
-    # 1) LLM 시도 (의미 동일 한국어 한 문장)
-    prompt = (
-        "역할: 너는 한국어 문장 변환기다.\n"
-        "출력은 한국어 **한 문장**만. 마크다운/주석/설명 금지.\n"
-        "규칙: 의미를 100% 유지. 숫자/단위/고유명사는 보존. 문장 끝 어미는 평서체.\n\n"
-        "[입력]\n" + t + "\n\n[출력]\n"
-    )
-    try:
-        out = _complete_with_any_llm(prompt)
-        if out and out.strip():
-            # 안전 정리
-            s = re.sub(r"\s+", " ", out).strip()
-            return s
-    except Exception:
-        pass
-
-    # 2) 폴백: Google 번역
-    if GoogleTranslator is not None:
-        try:
-            return GoogleTranslator(source="auto", target="ko").translate(t)
-        except Exception:
-            pass
-
-    # 3) 실패 시 원문 유지
-    return t
-    
 def _heuristic_breath_lines(text: str, strict: bool = True) -> list[str]:
     t = (text or "").strip()
     if not t:


### PR DESCRIPTION
## Summary
- Split scripts by punctuation before LLM clause splitting and reuse those clauses for SSML/TTS
- Convert clause batches to SSML and ASS in one pass while stripping all non-question punctuation and coloring high-pitch lines
- Remove code-based translations and translator fallbacks so language changes occur only in the SSML LLM

## Testing
- `python -m py_compile ssml_converter.py generate_timed_segments.py keyword_generator.py runner.py main.py image_generator.py best_subtitle_extractor.py best_subject_subtitle_extractor.py`


------
https://chatgpt.com/codex/tasks/task_e_68bceb0f2d088324a00aff863fd5b8e8